### PR TITLE
fix 細かい修正: bashからshに変更、appをapiで統一

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ dstatus:
 
 dlogin:
 	@echo "docker login"
-	@docker exec -it $(shell docker ps --all --format "{{.Names}}" | peco) /bin/bash
+	@docker exec -it $(shell docker ps --all --format "{{.Names}}" | peco) /bin/sh
 
 dclean:
 	@echo "docker clean"

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -48,7 +48,7 @@ func main() {
 		UserService: userService,
 	}
 
-	// Run App server
+	// Run Api server
 	server := handler.New(conf.Server.Port, services, conf.Server.RedirectURL)
 	log.Println("Start server")
 	if err := server.ListenAndServe(); err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  app:
+  api:
     image: golang:1.12-alpine 
     volumes:
     - .:/go/load-test-sample


### PR DESCRIPTION
## 実装の背景・目的
細かい修正

## やったこと
- alpineにした結果bashが利用できなくなったのでshを利用するように変更
- `app`と`api`で表記揺れしていたので統一
